### PR TITLE
Improve List Consistency, Fix Typos, and Organize MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,227 +1,230 @@
 # Awesome MCP Servers - Concise List
 
-Note that this list is continnuesly updating and improving. Please star this repo . It really worth to bookmark.
+Note that this list is continuously updating and improving. Please star this repo if you find it useful – it's worth bookmarking!
 
-### 📂 Browser controll
+### 📂 Browser Control
 
--   **[@recursechat/mcp-server-apple-shortcuts](https://github.com/recursechat/mcp-server-apple-shortcuts)**:  Integrates with macOS Shortcuts for automation via MCP.
--   **[@kimtth/mcp-aoai-web-browsing](https://github.com/kimtth/mcp-aoai-web-browsing)**:  Minimal implementation using Azure OpenAI and Playwright for web browsing.
--   **[@pskill9/web-search](https://github.com/pskill9/web-search)**:  Provides web search capabilities using Google results without requiring API keys.
--   **[@co-browser/browser-use-mcp-server](https://github.com/co-browser/browser-use-mcp-server)**: `browser-use` packaged as MCP server, with Docker support for Chromium and VNC.
--   **[@blackwhite084/playwright-plus-python-mcp](https://github.com/blackwhite084/playwright-plus-python-mcp)**:  Python-based MCP server leveraging Playwright, optimized for large language models.
--   **[@executeautomation/playwright-mcp-server](https://github.com/executeautomation/mcp-playwright)**:  Utilizes Playwright for web automation and data extraction within an MCP framework.
--   **[@automatalabs/mcp-server-playwright](https://github.com/Automata-Labs-team/MCP-Server-Playwright)**:  Controls web browsers via Playwright through MCP commands.
--   **[@modelcontextprotocol/server-puppeteer](https://github.com/modelcontextprotocol/servers/tree/main/src/puppeteer)**:  Automates web interactions and scraping using Puppeteer.
--   **[@kimtaeyoon83/mcp-server-youtube-transcript](https://github.com/kimtaeyoon83/mcp-server-youtube-transcript)**:  Extracts subtitles and transcripts from YouTube videos for AI processing.
-
+-   **[@recursechat/mcp-server-apple-shortcuts](https://github.com/recursechat/mcp-server-apple-shortcuts)**: Integrates with macOS Shortcuts for automation via MCP.
+-   **[@kimtth/mcp-aoai-web-browsing](https://github.com/kimtth/mcp-aoai-web-browsing)**: Implements minimal web browsing using Azure OpenAI and Playwright.
+-   **[@pskill9/web-search](https://github.com/pskill9/web-search)**: Provides web search capabilities using Google results without requiring API keys.
+-   **[@co-browser/browser-use-mcp-server](https://github.com/co-browser/browser-use-mcp-server)**: Packages `browser-use` as an MCP server, with Docker support for Chromium and VNC.
+-   **[@blackwhite084/playwright-plus-python-mcp](https://github.com/blackwhite084/playwright-plus-python-mcp)**: Leverages Playwright via Python, optimized for large language models.
+-   **[@executeautomation/playwright-mcp-server](https://github.com/executeautomation/mcp-playwright)**: Utilizes Playwright for web automation and data extraction within an MCP framework.
+-   **[@automatalabs/mcp-server-playwright](https://github.com/Automata-Labs-team/MCP-Server-Playwright)**: Controls web browsers via Playwright through MCP commands.
+-   **[modelcontextprotocol/server-puppeteer](https://github.com/modelcontextprotocol/servers/tree/main/src/puppeteer)**: Automates web interactions and scraping using Puppeteer (part of the official servers collection).
+-   **[@kimtaeyoon83/mcp-server-youtube-transcript](https://github.com/kimtaeyoon83/mcp-server-youtube-transcript)**: Extracts subtitles and transcripts from YouTube videos for AI processing.
 
 ### 🎨 Art & Culture
 
 -   **[burningion/video-editing-mcp](https://github.com/burningion/video-editing-mcp)**: Enables AI-driven video editing, analysis, and search within a video collection.
--   **[r-huijts/rijksmuseum-mcp](https://github.com/r-huijts/rijksmuseum-mcp)**:  Connects to the Rijksmuseum API for accessing art collections and details.
--  **[yuna0x0/anilist-mcp](https://github.com/yuna0x0/anilist-mcp)**: Provides information on anime and manga through integration with the AniList API.
+-   **[r-huijts/rijksmuseum-mcp](https://github.com/r-huijts/rijksmuseum-mcp)**: Connects to the Rijksmuseum API for accessing art collections and details.
+-   **[yuna0x0/anilist-mcp](https://github.com/yuna0x0/anilist-mcp)**: Provides information on anime and manga through integration with the AniList API.
 
 ### ☁️ Cloud Platforms
 
--   **[Cloudflare MCP Server](https://github.com/cloudflare/mcp-server-cloudflare)**:  Integrates with various Cloudflare services like Workers and KV.
--   **[alexei-led/aws-mcp-server](https://github.com/alexei-led/aws-mcp-server)**:  Enables secure execution of AWS CLI commands and prompt templates within Docker.
--   **[Kubernetes MCP Server](https://github.com/strowk/mcp-k8s-go)**:  Manages Kubernetes clusters through MCP interactions.
--   **[@flux159/mcp-server-kubernetes](https://github.com/Flux159/mcp-server-kubernetes)**: TypeScript server for controlling Kubernetes pods, deployments, and services.
--   **[@manusa/Kubernetes MCP Server](https://github.com/manusa/kubernetes-mcp-server)**: Kubernetes and OpenShift management with specialized cluster interaction tools.
-- **[wenhuwang/mcp-k8s-eye](https://github.com/wenhuwang/mcp-k8s-eye)** : Provides kubernetes management features and application health analysis.
+-   **[cloudflare/mcp-server-cloudflare](https://github.com/cloudflare/mcp-server-cloudflare)**: Integrates with various Cloudflare services like Workers and KV.
+-   **[alexei-led/aws-mcp-server](https://github.com/alexei-led/aws-mcp-server)**: Enables secure execution of AWS CLI commands and prompt templates within Docker.
+-   **[strowk/mcp-k8s-go](https://github.com/strowk/mcp-k8s-go)**: Manages Kubernetes clusters through MCP interactions (Go implementation).
+-   **[@flux159/mcp-server-kubernetes](https://github.com/Flux159/mcp-server-kubernetes)**: Controls Kubernetes pods, deployments, and services (TypeScript implementation).
+-   **[manusa/kubernetes-mcp-server](https://github.com/manusa/kubernetes-mcp-server)**: Manages Kubernetes and OpenShift with specialized cluster interaction tools (Java implementation).
+-   **[wenhuwang/mcp-k8s-eye](https://github.com/wenhuwang/mcp-k8s-eye)**: Provides Kubernetes management features and application health analysis.
 -   **[johnneerdael/netskope-mcp](https://github.com/johnneerdael/netskope-mcp)**: Accesses Netskope Private Access components and provides setup details.
--    **[nwiizo/tfmcp](https://github.com/nwiizo/tfmcp)**: Allows AI assistants to control Terraform environments for infrastructure management.
+-   **[nwiizo/tfmcp](https://github.com/nwiizo/tfmcp)**: Allows AI assistants to control Terraform environments for infrastructure management.
 
 ### 🖥️ Command Line
 
--   **[ferrislucas/iterm-mcp](https://github.com/ferrislucas/iterm-mcp)**:  Provides iTerm2 terminal access for command execution and output analysis.
--   **[g0t4/mcp-server-commands](https://github.com/g0t4/mcp-server-commands)**:  Executes arbitrary commands and scripts via MCP.
--   **[MladenSU/cli-mcp-server](https://github.com/MladenSU/cli-mcp-server)**:  Offers a command-line interface with configurable security policies.
--  **[tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server)**: Securely executes shell commands through the Model Context Protocol.
+-   **[ferrislucas/iterm-mcp](https://github.com/ferrislucas/iterm-mcp)**: Provides iTerm2 terminal access for command execution and output analysis.
+-   **[g0t4/mcp-server-commands](https://github.com/g0t4/mcp-server-commands)**: Executes arbitrary commands and scripts via MCP.
+-   **[MladenSU/cli-mcp-server](https://github.com/MladenSU/cli-mcp-server)**: Offers a command-line interface with configurable security policies.
+-   **[tumf/mcp-shell-server](https://github.com/tumf/mcp-shell-server)**: Securely executes shell commands through the Model Context Protocol.
 
 ### 💬 Communication
 
--   **[zcaceres/gtasks-mcp](https://github.com/zcaceres/gtasks-mcp)**:  Manages Google Tasks lists and items via MCP.
--   **[hannesrudolph/imessage-query-fastmcp-mcp-server](https://github.com/hannesrudolph/imessage-query-fastmcp-mcp-server)**:  Safely queries and analyzes iMessage conversations, including attachments.
--   **[@modelcontextprotocol/server-slack](https://github.com/modelcontextprotocol/servers/tree/main/src/slack)**:  Manages Slack channels and messages.
--   **[@modelcontextprotocol/server-bluesky](https://github.com/keturiosakys/bluesky-context-server)**: Connects and allows interaction with Bluesky social network instances.
--   **[MarkusPfundstein/mcp-gsuite](https://github.com/MarkusPfundstein/mcp-gsuite)**:  Interacts with Gmail and Google Calendar.
--   **[adhikasp/mcp-twikit](https://github.com/adhikasp/mcp-twikit)**: Access Twitter search and timeline data.
--   **[gotoolkits/wecombot](https://github.com/gotoolkits/mcp-wecombot-server.git)**: Sends messages to WeCom group robots.
-- **[AbdelStark/nostr-mcp](https://github.com/AbdelStark/nostr-mcp)**: Enables interaction with the Nostr protocol, including posting notes.
-- **[elie222/inbox-zero](https://github.com/elie222/inbox-zero/tree/main/apps/mcp-server)**:  Manages Gmail, identifying emails needing replies or follow-ups.
-- **[carterlasalle/mac_messages_mcp](https://github.com/carterlasalle/mac_messages_mcp)**: Securely accesses and analyzes iMessage data, with full send/receive support.
-- **[sawa-zen/vrchat-mcp](https://github.com/sawa-zen/vrchat-mcp)**: Interacts with the VRChat API to retrieve user, world, and avatar information.
-- **[arpitbatra123/mcp-googletasks](https://github.com/arpitbatra123/mcp-googletasks)**: Interfaces with the Google Tasks API for task management.
+-   **[zcaceres/gtasks-mcp](https://github.com/zcaceres/gtasks-mcp)**: Manages Google Tasks lists and items via MCP.
+-   **[hannesrudolph/imessage-query-fastmcp-mcp-server](https://github.com/hannesrudolph/imessage-query-fastmcp-mcp-server)**: Safely queries and analyzes iMessage conversations, including attachments.
+-   **[modelcontextprotocol/server-slack](https://github.com/modelcontextprotocol/servers/tree/main/src/slack)**: Manages Slack channels and messages (part of the official servers collection).
+-   **[keturiosakys/bluesky-context-server](https://github.com/keturiosakys/bluesky-context-server)**: Connects and allows interaction with Bluesky social network instances.
+-   **[MarkusPfundstein/mcp-gsuite](https://github.com/MarkusPfundstein/mcp-gsuite)**: Interacts with Gmail and Google Calendar.
+-   **[adhikasp/mcp-twikit](https://github.com/adhikasp/mcp-twikit)**: Accesses Twitter search and timeline data.
+-   **[gotoolkits/mcp-wecombot-server](https://github.com/gotoolkits/mcp-wecombot-server.git)**: Sends messages to WeCom group robots. (*Note: Link ends with .git*)
+-   **[AbdelStark/nostr-mcp](https://github.com/AbdelStark/nostr-mcp)**: Enables interaction with the Nostr protocol, including posting notes.
+-   **[elie222/inbox-zero-mcp](https://github.com/elie222/inbox-zero/tree/main/apps/mcp-server)**: Manages Gmail, identifying emails needing replies or follow-ups (part of the Inbox Zero project).
+-   **[carterlasalle/mac_messages_mcp](https://github.com/carterlasalle/mac_messages_mcp)**: Securely accesses, analyzes, sends, and receives iMessages on macOS.
+-   **[sawa-zen/vrchat-mcp](https://github.com/sawa-zen/vrchat-mcp)**: Interacts with the VRChat API to retrieve user, world, and avatar information.
+-   **[arpitbatra123/mcp-googletasks](https://github.com/arpitbatra123/mcp-googletasks)**: Interfaces with the Google Tasks API for task management.
 
 ### 👤 Customer Data Platforms
 
-- **[sergehuber/inoyu-mcp-unomi-server](https://github.com/sergehuber/inoyu-mcp-unomi-server)**: Accesses and updates user profiles on an Apache Unomi CDP server.
--   **[OpenDataMCP/OpenDataMCP](https://github.com/OpenDataMCP/OpenDataMCP)**:  Connects various Open Data sources to LLMs via MCP.
--   **[tinybirdco/mcp-tinybird](https://github.com/tinybirdco/mcp-tinybird)**:  Allows interaction with a Tinybird Workspace.
--   **[@iaptic/mcp-server-iaptic](https://github.com/iaptic/mcp-server-iaptic)**:  Connects to iaptic to retrieve customer purchase and app revenue data.
+-   **[sergehuber/inoyu-mcp-unomi-server](https://github.com/sergehuber/inoyu-mcp-unomi-server)**: Accesses and updates user profiles on an Apache Unomi CDP server.
+-   **[OpenDataMCP/OpenDataMCP](https://github.com/OpenDataMCP/OpenDataMCP)**: Connects various Open Data sources to LLMs via MCP.
+-   **[@iaptic/mcp-server-iaptic](https://github.com/iaptic/mcp-server-iaptic)**: Connects to iaptic to retrieve customer purchase and app revenue data.
 
 ### 🗄️ Databases
 
--    **[aliyun/alibabacloud-tablestore-mcp-server](https://github.com/aliyun/alibabacloud-tablestore-mcp-server)**: Provides access to Tablestore, including document management and semantic search.
--   **[cr7258/elasticsearch-mcp-server](https://github.com/cr7258/elasticsearch-mcp-server)**:  Enables interaction with Elasticsearch clusters.
--   **[domdomegg/airtable-mcp-server](https://github.com/domdomegg/airtable-mcp-server)**:  Provides read and write access to Airtable databases, including schema inspection.
+-   **[aliyun/alibabacloud-tablestore-mcp-server](https://github.com/aliyun/alibabacloud-tablestore-mcp-server)**: Provides access to Tablestore, including document management and semantic search.
+-   **[cr7258/elasticsearch-mcp-server](https://github.com/cr7258/elasticsearch-mcp-server)**: Enables interaction with Elasticsearch clusters.
+-   **[domdomegg/airtable-mcp-server](https://github.com/domdomegg/airtable-mcp-server)**: Provides read/write access to Airtable databases, including schema inspection.
 -   **[rashidazarang/airtable-mcp](https://github.com/rashidazarang/airtable-mcp)**: Directly connects AI tools to Airtable for comprehensive data manipulation.
--   **[LucasHild/mcp-server-bigquery](https://github.com/LucasHild/mcp-server-bigquery)**:  Allows querying and schema inspection of BigQuery databases.
--   **[c4pt0r/mcp-server-tidb](https://github.com/c4pt0r/mcp-server-tidb)**:  Provides access to TiDB databases, including schema inspection and querying.
--   **[ergut/mcp-bigquery-server](https://github.com/ergut/mcp-bigquery-server)**:  Enables direct access and querying of Google BigQuery.
--   **[ClickHouse/mcp-clickhouse](https://github.com/ClickHouse/mcp-clickhouse)**:  Offers schema inspection and querying capabilities for ClickHouse databases.
--   **[get-convex/convex-backend](https://stack.convex.dev/convex-mcp-server)**:  Introspects Convex tables, functions, and allows one-off queries.
+-   **[LucasHild/mcp-server-bigquery](https://github.com/LucasHild/mcp-server-bigquery)**: Allows querying and schema inspection of BigQuery databases.
+-   **[c4pt0r/mcp-server-tidb](https://github.com/c4pt0r/mcp-server-tidb)**: Provides access to TiDB databases, including schema inspection and querying.
+-   **[ergut/mcp-bigquery-server](https://github.com/ergut/mcp-bigquery-server)**: Enables direct access and querying of Google BigQuery.
+-   **[ClickHouse/mcp-clickhouse](https://github.com/ClickHouse/mcp-clickhouse)**: Offers schema inspection and querying capabilities for ClickHouse databases.
+-   **[get-convex/convex-mcp-server](https://stack.convex.dev/convex-mcp-server)**: Introspects Convex tables, functions, and allows one-off queries. (*Note: Links to Convex Stack page*)
 -   **[@gannonh/firebase-mcp](https://github.com/gannonh/firebase-mcp)**: Provides access to Firebase services like Auth, Firestore, and Storage.
 -   **[jovezhong/mcp-timeplus](https://github.com/jovezhong/mcp-timeplus)**: Manages Apache Kafka topics and queries streaming data via Timeplus SQL.
--   **[@fireproof-storage/mcp-database-server](https://github.com/fireproof-storage/mcp-database-server)**:  Offers a Fireproof ledger database with multi-user synchronization.
--   **[designcomputer/mysql_mcp_server](https://github.com/designcomputer/mysql_mcp_server)**:  Provides secure MySQL database operations with configurable access controls.
--   **[f4ww4z/mcp-mysql-server](https://github.com/f4ww4z/mcp-mysql-server)**:  Offers secure MySQL database interaction.
-- **[FreePeak/db-mcp-server](https://github.com/FreePeak/db-mcp-server)**: A high-performance multi-database server (MySQL & PostgreSQL) with built-in tools for query execution, transaction management, and schema exploration.
--   **[@modelcontextprotocol/server-postgres](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres)**:  Enables querying and schema inspection of PostgreSQL databases.
--   **[@modelcontextprotocol/server-sqlite](https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite)**:  Provides SQLite database operations with built-in analysis.
+-   **[@fireproof-storage/mcp-database-server](https://github.com/fireproof-storage/mcp-database-server)**: Offers a Fireproof ledger database with multi-user synchronization.
+-   **[designcomputer/mysql_mcp_server](https://github.com/designcomputer/mysql_mcp_server)**: Provides secure MySQL database operations with configurable access controls.
+-   **[f4ww4z/mcp-mysql-server](https://github.com/f4ww4z/mcp-mysql-server)**: Offers secure MySQL database interaction.
+-   **[FreePeak/db-mcp-server](https://github.com/FreePeak/db-mcp-server)**: Provides a high-performance multi-database server (MySQL & PostgreSQL) with tools for query execution, transactions, and schema exploration.
+-   **[modelcontextprotocol/server-postgres](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres)**: Enables querying and schema inspection of PostgreSQL databases (part of the official servers collection).
+-   **[modelcontextprotocol/server-sqlite](https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite)**: Provides SQLite database operations with built-in analysis (part of the official servers collection).
 -   **[@joshuarileydev/supabase-mcp-server](https://github.com/joshuarileydev/supabase)**: Manages Supabase projects and organizations.
--   **[@alexanderzuev/supabase-mcp-server](https://github.com/alexander-zuev/supabase-mcp-server)**: Supports SQL query execution and database exploration within Supabase.
+-   **[@alexander-zuev/supabase-mcp-server](https://github.com/alexander-zuev/supabase-mcp-server)**: Supports SQL query execution and database exploration within Supabase.
 -   **[ktanaka101/mcp-server-duckdb](https://github.com/ktanaka101/mcp-server-duckdb)**: Integrates with DuckDB, offering schema inspection and query features.
 -   **[Dataring-engineering/mcp-server-trino](https://github.com/Dataring-engineering/mcp-server-trino)**: Connects to Trino Clusters for querying and data access.
-- **[furey/mongodb-lens](https://github.com/furey/mongodb-lens)**: Provides a fully-featured MCP server for MongoDB Databases.
+-   **[furey/mongodb-lens](https://github.com/furey/mongodb-lens)**: Provides a fully-featured MCP server for MongoDB Databases.
 -   **[QuantGeekDev/mongo-mcp](https://github.com/QuantGeekDev/mongo-mcp)**: Enables direct interaction with MongoDB databases.
--  **[kiliczsh/mcp-mongo-server](https://github.com/kiliczsh/mcp-mongo-server)** : A server for interacting with MongoDB.
--   **[tinybirdco/mcp-tinybird](https://github.com/tinybirdco/mcp-tinybird)**:  Integrates with Tinybird, providing query and API capabilities.
--   **[KashiwaByte/vikingdb-mcp-server](https://github.com/KashiwaByte/vikingdb-mcp-server)**:  Integrates with VikingDB for vector store and search functionalities.
-- **[neo4j-contrib/mcp-neo4j](https://github.com/neo4j-contrib/mcp-neo4j)**: Enables Model Context Protocol interactions with Neo4j databases.
--  **[niledatabase/nile-mcp-server](https://github.com/niledatabase/nile-mcp-server)** Manage and query Postgres databases, tenants, users, auth using LLMs.
--  **[isaacwasserman/mcp-snowflake-server](https://github.com/isaacwasserman/mcp-snowflake-server)**:  Snowflake integration with read and (optional) write operations and insight tracking.
--  **[hannesrudolph/sqlite-explorer-fastmcp-mcp-server](https://github.com/hannesrudolph/sqlite-explorer-fastmcp-mcp-server)**: Safe, read-only access to SQLite databases with query validation.
--  **[sirmews/mcp-pinecone](https://github.com/sirmews/mcp-pinecone)**: Integrates with Pinecone, offering vector search capabilities.
--   **[runekaagaard/mcp-alchemy](https://github.com/runekaagaard/mcp-alchemy)**:  Universal SQLAlchemy-based database integration, supporting multiple database types.
-- **[mcp-server-jdbc](https://github.com/quarkiverse/quarkus-mcp-servers/tree/main/jdbc)**: Connects to any JDBC-compatible database.
-- **[pab1it0/adx-mcp-server](https://github.com/pab1it0/adx-mcp-server)**: Allows querying and analyzing of Azure Data Explorer databases.
-- **[pab1it0/prometheus-mcp-server](https://github.com/pab1it0/prometheus-mcp-server)**: Provides querying and analysis of Prometheus monitoring system.
--  **[neondatabase/mcp-server-neon](https://github.com/neondatabase/mcp-server-neon)**: Enables creating and managing Postgres databases with Neon Serverless Postgres.
--  **[XGenerationLab/xiyan_mcp_server](https://github.com/XGenerationLab/xiyan_mcp_server)**: Supports fetching database data via natural language queries, powered by XiyanSQL.
-- **[bytebase/dbhub](https://github.com/bytebase/dbhub)**: A universal database MCP server with support for mainstream databases.
+-   **[kiliczsh/mcp-mongo-server](https://github.com/kiliczsh/mcp-mongo-server)**: Interacts with MongoDB databases.
+-   **[tinybirdco/mcp-tinybird](https://github.com/tinybirdco/mcp-tinybird)**: Integrates with Tinybird, providing query and API capabilities.
+-   **[KashiwaByte/vikingdb-mcp-server](https://github.com/KashiwaByte/vikingdb-mcp-server)**: Integrates with VikingDB for vector store and search functionalities.
+-   **[neo4j-contrib/mcp-neo4j](https://github.com/neo4j-contrib/mcp-neo4j)**: Enables Model Context Protocol interactions with Neo4j databases.
+-   **[niledatabase/nile-mcp-server](https://github.com/niledatabase/nile-mcp-server)**: Manages and queries Postgres databases, tenants, users, and auth using LLMs via Nile.
+-   **[isaacwasserman/mcp-snowflake-server](https://github.com/isaacwasserman/mcp-snowflake-server)**: Integrates with Snowflake with read/write operations and insight tracking.
+-   **[hannesrudolph/sqlite-explorer-fastmcp-mcp-server](https://github.com/hannesrudolph/sqlite-explorer-fastmcp-mcp-server)**: Provides safe, read-only access to SQLite databases with query validation.
+-   **[sirmews/mcp-pinecone](https://github.com/sirmews/mcp-pinecone)**: Integrates with Pinecone, offering vector search capabilities.
+-   **[runekaagaard/mcp-alchemy](https://github.com/runekaagaard/mcp-alchemy)**: Provides universal SQLAlchemy-based database integration, supporting multiple database types.
+-   **[quarkiverse/quarkus-mcp-jdbc](https://github.com/quarkiverse/quarkus-mcp-servers/tree/main/jdbc)**: Connects to any JDBC-compatible database (part of Quarkus MCP Servers).
+-   **[pab1it0/adx-mcp-server](https://github.com/pab1it0/adx-mcp-server)**: Allows querying and analyzing of Azure Data Explorer databases.
+-   **[pab1it0/prometheus-mcp-server](https://github.com/pab1it0/prometheus-mcp-server)**: Provides querying and analysis of Prometheus monitoring system.
+-   **[neondatabase/mcp-server-neon](https://github.com/neondatabase/mcp-server-neon)**: Enables creating and managing Postgres databases with Neon Serverless Postgres.
+-   **[XGenerationLab/xiyan_mcp_server](https://github.com/XGenerationLab/xiyan_mcp_server)**: Supports fetching database data via natural language queries, powered by XiyanSQL.
+-   **[bytebase/dbhub](https://github.com/bytebase/dbhub)**: Provides a universal database MCP server with support for mainstream databases.
 -   **[GreptimeTeam/greptimedb-mcp-server](https://github.com/GreptimeTeam/greptimedb-mcp-server)**: Enables querying of GreptimeDB.
 -   **[idoru/influxdb-mcp-server](https://github.com/idoru/influxdb-mcp-server)**: Executes queries against InfluxDB OSS API v2.
-- **[xing5/mcp-google-sheets](https://github.com/xing5/mcp-google-sheets)**: A server for interacting with Google Sheets, providing create, read, update, and manage functionalities.
+-   **[xing5/mcp-google-sheets](https://github.com/xing5/mcp-google-sheets)**: Interacts with Google Sheets, providing create, read, update, and manage functionalities.
 
 ### 💻 Developer Tools
 
--  **[21st-dev/Magic-MCP](https://github.com/21st-dev/magic-mcp)**:  Generates UI components based on 21st.dev design principles.
--   **[Coment-ML/Opik-MCP](https://github.com/comet-ml/opik-mcp)**:  Enables querying of LLM observability data captured by Opik.
--   **[GLips/Figma-Context-MCP](https://github.com/GLips/Figma-Context-MCP)**:  Gives coding agents direct access to Figma data.
--   **[QuantGeekDev/docker-mcp](https://github.com/QuantGeekDev/docker-mcp)**:  Manages Docker containers via MCP.
--   **[zcaceres/fetch-mcp](https://github.com/zcaceres/fetch-mcp)**:  Fetches JSON, text, and HTML data flexibly.
--   **[r-huijts/xcode-mcp-server](https://github.com/r-huijts/xcode-mcp-server)**:  Integrates with Xcode for project management and build automation.
--   **[snaggle-ai/openapi-mcp-server](https://github.com/snaggle-ai/openapi-mcp-server)**:  Connects to HTTP/REST APIs using an Open API specification.
--  **[jetbrains/mcpProxy](https://github.com/JetBrains/mcpProxy)**: Connects to JetBrains IDEs for development tasks.
--  **[tumf/mcp-text-editor](https://github.com/tumf/mcp-text-editor)**: A line-oriented text file editor, optimized for LLM interaction and minimal token usage.
--   **[@joshuarileydev/simulator-mcp-server](https://github.com/JoshuaRileyDev/simulator-mcp-server)**:  Controls iOS Simulators.
--   **[@joshuarileydev/app-store-connect-mcp-server](https://github.com/JoshuaRileyDev/app-store-connect-mcp-server)**:  Communicates with the App Store Connect API.
--   **[@sammcj/mcp-package-version](https://github.com/sammcj/mcp-package-version)**:  Helps LLMs suggest the latest stable package versions.
--   **[@delano/postman-mcp-server](https://github.com/delano/postman-mcp-server)**:  Interacts with the Postman API.
--   **[@vivekvells/mcp-pandoc](https://github.com/vivekVells/mcp-pandoc)**:  Converts document formats using Pandoc.
--   **[@pskill9/website-downloader](https://github.com/pskill9/website-downloader)**:  Downloads entire websites using wget, preserving structure.
--   **[@lamemind/mcp-server-multiverse](https://github.com/lamemind/mcp-server-multiverse)**:  Allows multiple isolated instances of MCP servers to coexist.
-- **[@j4c0bs/mcp-server-sql-analyzer](https://github.com/j4c0bs/mcp-server-sql-analyzer)**: Provides SQL analysis, linting, and dialect conversion using SQLGlot.
--   **[@haris-musa/excel-mcp-server](https://github.com/haris-musa/excel-mcp-server)**:  Manipulates Excel workbooks, including data, formatting, and charts.
-- **[xcodebuild](https://github.com/ShenghaiWang/xcodebuild)** Build iOS Xcode workspace/project and feedback errors to LLMs.
+-   **[21st-dev/Magic-MCP](https://github.com/21st-dev/magic-mcp)**: Generates UI components based on 21st.dev design principles.
+-   **[Comet-ML/Opik-MCP](https://github.com/comet-ml/opik-mcp)**: Enables querying of LLM observability data captured by Opik.
+-   **[GLips/Figma-Context-MCP](https://github.com/GLips/Figma-Context-MCP)**: Gives coding agents direct access to Figma data.
+-   **[QuantGeekDev/docker-mcp](https://github.com/QuantGeekDev/docker-mcp)**: Manages Docker containers via MCP.
+-   **[r-huijts/xcode-mcp-server](https://github.com/r-huijts/xcode-mcp-server)**: Integrates with Xcode for project management and build automation.
+-   **[snaggle-ai/openapi-mcp-server](https://github.com/snaggle-ai/openapi-mcp-server)**: Connects to HTTP/REST APIs using an OpenAPI specification.
+-   **[JetBrains/mcpProxy](https://github.com/JetBrains/mcpProxy)**: Connects to JetBrains IDEs for development tasks.
+-   **[tumf/mcp-text-editor](https://github.com/tumf/mcp-text-editor)**: Provides a line-oriented text file editor, optimized for LLM interaction.
+-   **[@joshuarileydev/simulator-mcp-server](https://github.com/JoshuaRileyDev/simulator-mcp-server)**: Controls iOS Simulators.
+-   **[@joshuarileydev/app-store-connect-mcp-server](https://github.com/JoshuaRileyDev/app-store-connect-mcp-server)**: Communicates with the App Store Connect API.
+-   **[@delano/postman-mcp-server](https://github.com/delano/postman-mcp-server)**: Interacts with the Postman API.
+-   **[@haris-musa/excel-mcp-server](https://github.com/haris-musa/excel-mcp-server)**: Manipulates Excel workbooks, including data, formatting, and charts.
+-   **[ShenghaiWang/xcodebuild](https://github.com/ShenghaiWang/xcodebuild)**: Builds iOS Xcode workspace/project and feedbacks errors to LLMs.
 -   **[@jasonjmcghee/claude-debugs-for-you](https://github.com/jasonjmcghee/claude-debugs-for-you)**: Enables automatic debugging via breakpoints and expression evaluation.
-- **[@Jktfe/serveMyAPI](https://github.com/Jktfe/serveMyAPI)**: Securely stores and accesses API keys across projects using the macOS Keychain.
--  **[@xzq.xu/jvm-mcp-server](https://github.com/xzq-xu/jvm-mcp-server)**:  An MCP server implementation for JVM-based environments.
-- **[@yangkyeongmo@/mcp-server-apache-airflow](https://github.com/yangkyeongmo/mcp-server-apache-airflow)**: Connects to Apache Airflow using the official client.
--   **[hyperb1iss/droidmind](https://github.com/hyperb1iss/droidmind)**:  Controls Android devices, enabling UI automation and debugging.
--  **[Rootly-AI-Labs/Rootly-MCP-server](https://github.com/Rootly-AI-Labs/Rootly-MCP-server)**: Integrates with the Rootly incident management platform.
--   **[YuChenSSR/mindmap-mcp-server](https://github.com/YuChenSSR/mindmap-mcp-server)**:  Generates interactive mindmaps.
--  **[SDGLBL/mcp-claude-code](https://github.com/SDGLBL/mcp-claude-code)**: Implements Claude Code capabilities using MCP, enabling code understanding and project analysis.
+-   **[@Jktfe/serveMyAPI](https://github.com/Jktfe/serveMyAPI)**: Securely stores and accesses API keys across projects using the macOS Keychain.
+-   **[@xzq-xu/jvm-mcp-server](https://github.com/xzq-xu/jvm-mcp-server)**: Implements an MCP server for JVM-based environments.
+-   **[@yangkyeongmo/mcp-server-apache-airflow](https://github.com/yangkyeongmo/mcp-server-apache-airflow)**: Connects to Apache Airflow using the official client.
+-   **[hyperb1iss/droidmind](https://github.com/hyperb1iss/droidmind)**: Controls Android devices, enabling UI automation and debugging.
+-   **[Rootly-AI-Labs/Rootly-MCP-server](https://github.com/Rootly-AI-Labs/Rootly-MCP-server)**: Integrates with the Rootly incident management platform.
+-   **[YuChenSSR/mindmap-mcp-server](https://github.com/YuChenSSR/mindmap-mcp-server)**: Generates interactive mindmaps.
+-   **[SDGLBL/mcp-claude-code](https://github.com/SDGLBL/mcp-claude-code)**: Implements Claude Code capabilities using MCP, enabling code understanding and project analysis.
 
 ### 🧮 Data Science Tools
+
 -   **[ChronulusAI/chronulus-mcp](https://github.com/ChronulusAI/chronulus-mcp)**: Uses Chronulus AI for forecasting and predictions.
--   **[zcaceres/markdownify-mcp](https://github.com/zcaceres/markdownify-mcp)**:  Converts various file types and web content to Markdown.
--  **[@reading-plus-ai/mcp-server-data-exploration](https://github.com/reading-plus-ai/mcp-server-data-exploration)**:  Enables autonomous data exploration on .csv-based datasets
+-   **[@reading-plus-ai/mcp-server-data-exploration](https://github.com/reading-plus-ai/mcp-server-data-exploration)**: Enables autonomous data exploration on `.csv`-based datasets.
 
 ### 📂 File Systems
 
--   **[@modelcontextprotocol/server-filesystem](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem)**:  Provides direct access to the local file system.
--   **[@modelcontextprotocol/server-google-drive](https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive)**:  Integrates with Google Drive for file listing and searching.
+-   **[modelcontextprotocol/server-filesystem](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem)**: Provides direct access to the local file system (part of the official servers collection).
+-   **[modelcontextprotocol/server-google-drive](https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive)**: Integrates with Google Drive for file listing and searching (part of the official servers collection).
 -   **[hmk/box-mcp-server](https://github.com/hmk/box-mcp-server)**: Provides listing, reading and searching files on Box.
--   **[mark3labs/mcp-filesystem-server](https://github.com/mark3labs/mcp-filesystem-server)**:  Golang implementation for local file system access.
--   **[mamertofabian/mcp-everything-search](https://github.com/mamertofabian/mcp-everything-search)**:  Provides fast Windows file search using Everything SDK.
--   **[cyberchitta/llm-context.py](https://github.com/cyberchitta/llm-context.py)**:  Shares code context with LLMs via MCP or clipboard.
--   **[filesystem@quarkiverse/quarkus-mcp-servers](https://github.com/quarkiverse/quarkus-mcp-servers/tree/main/filesystem)**:  A Java-based filesystem for browsing and editing files.
-- **[Xuanwo/mcp-server-opendal](https://github.com/Xuanwo/mcp-server-opendal)** Access storage services with Apache OpenDAL.
+-   **[mark3labs/mcp-filesystem-server](https://github.com/mark3labs/mcp-filesystem-server)**: Provides local file system access (Golang implementation).
+-   **[mamertofabian/mcp-everything-search](https://github.com/mamertofabian/mcp-everything-search)**: Provides fast Windows file search using Everything SDK.
+-   **[cyberchitta/llm-context.py](https://github.com/cyberchitta/llm-context.py)**: Shares code context with LLMs via MCP or clipboard.
+-   **[quarkiverse/quarkus-mcp-filesystem](https://github.com/quarkiverse/quarkus-mcp-servers/tree/main/filesystem)**: Provides file system browsing and editing (part of Quarkus MCP Servers, Java implementation).
+-   **[Xuanwo/mcp-server-opendal](https://github.com/Xuanwo/mcp-server-opendal)**: Accesses various storage services via Apache OpenDAL.
 
 ### 💰 Finance & Fintech
 
-- **[heurist-network/heurist-mesh-mcp-server](https://github.com/heurist-network/heurist-mesh-mcp-server)**:  Provides access to web3 AI agents for blockchain analysis and smart contract auditing.
--   **[@base/base-mcp](https://github.com/base/base-mcp)**:  Integrates with Base Network for onchain tools and Coinbase API interactions.
--   **[QuantGeekDev/coincap-mcp](https://github.com/QuantGeekDev/coincap-mcp)**:  Provides real-time cryptocurrency market data from CoinCap.
--   **[anjor/coinmarket-mcp-server](https://github.com/anjor/coinmarket-mcp-server)**:  Fetches cryptocurrency listings and quotes from the Coinmarket API.
--   **[berlinbra/alpha-vantage-mcp](https://github.com/berlinbra/alpha-vantage-mcp)**:  Fetches stock and crypto information from Alpha Vantage.
--   **[ferdousbhai/tasty-agent](https://github.com/ferdousbhai/tasty-agent)**:  Handles trading activities on Tastytrade via the Tastyworks API.
--   **[ferdousbhai/investor-agent](https://github.com/ferdousbhai/investor-agent)**:  Fetches stock market data and options recommendations from Yahoo Finance.
--   **[mcpdotdirect/evm-mcp-server](https://github.com/mcpdotdirect/evm-mcp-server)**:  Provides blockchain services for 30+ EVM networks.
--   **[bankless/onchain-mcp](https://github.com/Bankless/onchain-mcp/)** : Uses Bankless Onchain API for smart contract interaction and querying transaction data.
--  **[kukapay/cryptopanic-mcp-server](https://github.com/kukapay/cryptopanic-mcp-server)**: Delivers cryptocurrency news to AI agents via CryptoPanic.
--  **[kukapay/whale-tracker-mcp](https://github.com/kukapay/whale-tracker-mcp)**: Tracks cryptocurrency whale transactions.
--  **[kukapay/crypto-feargreed-mcp](https://github.com/kukapay/crypto-feargreed-mcp)**: Provides real-time and historical Crypto Fear & Greed Index data.
--   **[kukapay/dune-analytics-mcp](https://github.com/kukapay/dune-analytics-mcp)**:  Bridges Dune Analytics data to AI agents.
--  **[kukapay/pancakeswap-poolspy-mcp](https://github.com/kukapay/pancakeswap-poolspy-mcp)**:  Tracks newly created pools on Pancake Swap.
--   **[kukapay/uniswap-poolspy-mcp](https://github.com/kukapay/uniswap-poolspy-mcp)**:  Tracks newly created liquidity pools on Uniswap.
-- **[kukapay/uniswap-trader-mcp](https://github.com/kukapay/uniswap-trader-mcp)**: Automates token swaps on Uniswap DEX.
--  **[kukapay/token-minter-mcp](https://github.com/kukapay/token-minter-mcp)**:  Allows AI agents to mint ERC-20 tokens.
+-   **[heurist-network/heurist-mesh-mcp-server](https://github.com/heurist-network/heurist-mesh-mcp-server)**: Provides access to web3 AI agents for blockchain analysis and smart contract auditing.
+-   **[@base/base-mcp](https://github.com/base/base-mcp)**: Integrates with Base Network for onchain tools and Coinbase API interactions.
+-   **[QuantGeekDev/coincap-mcp](https://github.com/QuantGeekDev/coincap-mcp)**: Provides real-time cryptocurrency market data from CoinCap.
+-   **[anjor/coinmarket-mcp-server](https://github.com/anjor/coinmarket-mcp-server)**: Fetches cryptocurrency listings and quotes from the Coinmarket API.
+-   **[berlinbra/alpha-vantage-mcp](https://github.com/berlinbra/alpha-vantage-mcp)**: Fetches stock and crypto information from Alpha Vantage.
+-   **[ferdousbhai/tasty-agent](https://github.com/ferdousbhai/tasty-agent)**: Handles trading activities on Tastytrade via the Tastyworks API.
+-   **[ferdousbhai/investor-agent](https://github.com/ferdousbhai/investor-agent)**: Fetches stock market data and options recommendations from Yahoo Finance.
+-   **[mcpdotdirect/evm-mcp-server](https://github.com/mcpdotdirect/evm-mcp-server)**: Provides blockchain services for 30+ EVM networks.
+-   **[Bankless/onchain-mcp](https://github.com/Bankless/onchain-mcp/)**: Uses Bankless Onchain API for smart contract interaction and querying transaction data.
+-   **[kukapay/cryptopanic-mcp-server](https://github.com/kukapay/cryptopanic-mcp-server)**: Delivers cryptocurrency news to AI agents via CryptoPanic.
+-   **[kukapay/whale-tracker-mcp](https://github.com/kukapay/whale-tracker-mcp)**: Tracks cryptocurrency whale transactions.
+-   **[kukapay/crypto-feargreed-mcp](https://github.com/kukapay/crypto-feargreed-mcp)**: Provides real-time and historical Crypto Fear & Greed Index data.
+-   **[kukapay/dune-analytics-mcp](https://github.com/kukapay/dune-analytics-mcp)**: Bridges Dune Analytics data to AI agents.
+-   **[kukapay/pancakeswap-poolspy-mcp](https://github.com/kukapay/pancakeswap-poolspy-mcp)**: Tracks newly created pools on Pancake Swap.
+-   **[kukapay/uniswap-poolspy-mcp](https://github.com/kukapay/uniswap-poolspy-mcp)**: Tracks newly created liquidity pools on Uniswap.
+-   **[kukapay/uniswap-trader-mcp](https://github.com/kukapay/uniswap-trader-mcp)**: Automates token swaps on Uniswap DEX.
+-   **[kukapay/token-minter-mcp](https://github.com/kukapay/token-minter-mcp)**: Allows AI agents to mint ERC-20 tokens.
 -   **[kukapay/thegraph-mcp](https://github.com/kukapay/thegraph-mcp)**: Provides indexed blockchain data from The Graph to AI agents.
 
 ### 🎮 Gaming
-- **[Coding-Solo/godot-mcp](https://github.com/Coding-Solo/godot-mcp)**: Interacts with the Godot game engine for editing, running, and managing scenes.
--  **[rishijatia/fantasy-pl-mcp](https://github.com/rishijatia/fantasy-pl-mcp/)**: Offers real-time Fantasy Premier League data and analysis.
-- **[CoderGamester/mcp-unity](https://github.com/CoderGamester/mcp-unity)**: MCP Server for Unity3d Game Engine integration.
+
+-   **[Coding-Solo/godot-mcp](https://github.com/Coding-Solo/godot-mcp)**: Interacts with the Godot game engine for editing, running, and managing scenes.
+-   **[rishijatia/fantasy-pl-mcp](https://github.com/rishijatia/fantasy-pl-mcp/)**: Offers real-time Fantasy Premier League data and analysis.
+-   **[CoderGamester/mcp-unity](https://github.com/CoderGamester/mcp-unity)**: Integrates with the Unity3D Game Engine via MCP.
 
 ### 🧠 Knowledge & Memory
 
--   **[@modelcontextprotocol/server-memory](https://github.com/modelcontextprotocol/servers/tree/main/src/memory)**:  Provides a knowledge graph-based persistent memory system.
--   **[/CheMiguel23/MemoryMesh](https://github.com/CheMiguel23/MemoryMesh)**: Enhanced graph-based memory focused on AI role-play.
--   **[/topoteretes/cognee](https://github.com/topoteretes/cognee/tree/dev/cognee-mcp)**: Memory manager for AI using graph and vector stores, with ingestion from 30+ data sources.
--   **[@hannesrudolph/mcp-ragdocs](https://github.com/hannesrudolph/mcp-ragdocs)**:  Retrieves and processes documentation using vector search.
+-   **[modelcontextprotocol/server-memory](https://github.com/modelcontextprotocol/servers/tree/main/src/memory)**: Provides a knowledge graph-based persistent memory system (part of the official servers collection).
+-   **[CheMiguel23/MemoryMesh](https://github.com/CheMiguel23/MemoryMesh)**: Provides enhanced graph-based memory focused on AI role-play.
+-   **[topoteretes/cognee-mcp](https://github.com/topoteretes/cognee/tree/dev/cognee-mcp)**: Manages AI memory using graph/vector stores, with ingestion from 30+ data sources (part of Cognee project).
+-   **[@hannesrudolph/mcp-ragdocs](https://github.com/hannesrudolph/mcp-ragdocs)**: Retrieves and processes documentation using vector search.
 -   **[@kaliaboi/mcp-zotero](https://github.com/kaliaboi/mcp-zotero)**: Connects LLMs to Zotero Cloud collections and sources.
-- **[mcp-summarizer](https://github.com/0xshellming/mcp-summarizer)**: Provides AI summarization for multiple content types.
--   **[graphlit-mcp-server](https://github.com/graphlit/graphlit-mcp-server)**: Ingests data from various sources into a Graphlit project for searching and retrieval.
+-   **[graphlit/graphlit-mcp-server](https://github.com/graphlit/graphlit-mcp-server)**: Ingests data from various sources into a Graphlit project for searching and retrieval.
 
 ### 🗺️ Location Services
 
--   **[@modelcontextprotocol/server-google-maps](https://github.com/modelcontextprotocol/servers/tree/main/src/google-maps)**:  Provides location services, routing, and place details from Google Maps.
--   **[SecretiveShell/MCP-timeserver](https://github.com/SecretiveShell/MCP-timeserver)**:  Provides the current time in any timezone.
--   **[webcoderz/MCP-Geo](https://github.com/webcoderz/MCP-Geo)**:  Offers geocoding capabilities using various services.
--   **[@briandconnelly/mcp-server-ipinfo](https://github.com/briandconnelly/mcp-server-ipinfo)**:  Provides IP address geolocation and network information.
-- **[QGIS MCP](https://github.com/jjsantos01/qgis_mcp)**: Integrates QGIS Desktop with Claude AI for project creation and code execution.
-- **[kukapay/nearby-search-mcp](https://github.com/kukapay/nearby-search-mcp)**: Enables nearby place searches using IP-based location detection.
+-   **[modelcontextprotocol/server-google-maps](https://github.com/modelcontextprotocol/servers/tree/main/src/google-maps)**: Provides location services, routing, and place details from Google Maps (part of the official servers collection).
+-   **[webcoderz/MCP-Geo](https://github.com/webcoderz/MCP-Geo)**: Offers geocoding capabilities using various services.
+-   **[@briandconnelly/mcp-server-ipinfo](https://github.com/briandconnelly/mcp-server-ipinfo)**: Provides IP address geolocation and network information via ipinfo.io.
+-   **[jjsantos01/qgis_mcp](https://github.com/jjsantos01/qgis_mcp)**: Integrates QGIS Desktop with Claude AI for project creation and code execution.
+-   **[kukapay/nearby-search-mcp](https://github.com/kukapay/nearby-search-mcp)**: Enables nearby place searches using IP-based location detection.
 
 ### 🎯 Marketing
--   **[Open Strategy Partners Marketing Tools](https://github.com/open-strategy-partners/osp_marketing_tools)**: Provides a set of marketing tools from Open Strategy Partners.
+
+-   **[open-strategy-partners/osp_marketing_tools](https://github.com/open-strategy-partners/osp_marketing_tools)**: Provides a set of marketing tools from Open Strategy Partners.
 
 ### 📊 Monitoring
 
--   **[@modelcontextprotocol/server-sentry](https://github.com/modelcontextprotocol/servers/tree/main/src/sentry)**:  Integrates with Sentry.io for error tracking.
--   **[@modelcontextprotocol/server-raygun](https://github.com/MindscapeHQ/mcp-server-raygun)**: Integrates with Raygun API for crash reporting.
--   **[metoro-io/metoro-mcp-server](https://github.com/metoro-io/metoro-mcp-server)**:  Queries and interacts with Kubernetes environments monitored by Metoro.
--   **[grafana/mcp-grafana](https://github.com/grafana/mcp-grafana)**:  Searches dashboards and queries datasources in Grafana.
+-   **[modelcontextprotocol/server-sentry](https://github.com/modelcontextprotocol/servers/tree/main/src/sentry)**: Integrates with Sentry.io for error tracking (part of the official servers collection).
+-   **[MindscapeHQ/mcp-server-raygun](https://github.com/MindscapeHQ/mcp-server-raygun)**: Integrates with Raygun API for crash reporting.
+-   **[metoro-io/metoro-mcp-server](https://github.com/metoro-io/metoro-mcp-server)**: Queries and interacts with Kubernetes environments monitored by Metoro.
+-   **[grafana/mcp-grafana](https://github.com/grafana/mcp-grafana)**: Searches dashboards and queries datasources in Grafana.
 -   **[pydantic/logfire-mcp](https://github.com/pydantic/logfire-mcp)**: Accesses OpenTelemetry traces and metrics through Logfire.
-- **[seekrays/mcp-monitor](https://github.com/seekrays/mcp-monitor)**: Provides system monitoring via MCP, exposing various metrics.
-- **[hyperb1iss/lucidity-mcp](https://github.com/hyperb1iss/lucidity-mcp)**: Provides intelligent, prompt-based analysis of AI-generated code across multiple dimensions.
+-   **[seekrays/mcp-monitor](https://github.com/seekrays/mcp-monitor)**: Provides system monitoring via MCP, exposing various metrics.
+-   **[hyperb1iss/lucidity-mcp](https://github.com/hyperb1iss/lucidity-mcp)**: Provides intelligent, prompt-based analysis of AI-generated code across multiple dimensions.
 
 ### 🔎 Search
 
--   **[@modelcontextprotocol/server-brave-search](https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search)**:  Performs web searches using Brave's Search API.
--   **[@angheljf/nyt](https://github.com/angheljf/nyt)**:  Searches articles using the NYTimes API.
--   **[@modelcontextprotocol/server-fetch](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch)**: Efficiently fetches and processes web content.
--   **[ac3xx/mcp-servers-kagi](https://github.com/ac3xx/mcp-servers-kagi)**:  Integrates with the Kagi search API.
-- **[exa-labs/exa-mcp-server](https://github.com/exa-labs/exa-mcp-server)**: Provides access to the Exa AI Search API.
--  **[fatwang2/search1api-mcp](https://github.com/fatwang2/search1api-mcp)**: Performs searches via search1api.
+-   **[modelcontextprotocol/server-brave-search](https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search)**: Performs web searches using Brave's Search API (part of the official servers collection).
+-   **[@angheljf/nyt](https://github.com/angheljf/nyt)**: Searches articles using the NYTimes API.
+-   **[ac3xx/mcp-servers-kagi](https://github.com/ac3xx/mcp-servers-kagi)**: Integrates with the Kagi search API.
+-   **[exa-labs/exa-mcp-server](https://github.com/exa-labs/exa-mcp-server)**: Provides access to the Exa AI Search API.
+-   **[fatwang2/search1api-mcp](https://github.com/fatwang2/search1api-mcp)**: Performs searches via search1api.
 -   **[Tomatio13/mcp-server-tavily](https://github.com/Tomatio13/mcp-server-tavily)**: Integrates with Tavily AI search API.
-- **[kshern/mcp-tavily](https://github.com/kshern/mcp-tavily.git)**: Integrates with Tavily AI search API
-- **[blazickjp/arxiv-mcp-server](https://github.com/blazickjp/arxiv-mcp-server)**: Searches research papers on ArXiv.
--  **[mzxrai/mcp-webresearch](https://github.com/mzxrai/mcp-webresearch)**:  Performs deep web research using Google search.
--  **[andybrandt/mcp-simple-arxiv](https://github.com/andybrandt/mcp-simple-arxiv)**: Allows searching and reading papers from arXiv.
--  **[andybrandt/mcp-simple-pubmed](https://github.com/andybrandt/mcp-simple-pubmed)**: Allows searching and reading papers from PubMed.
+-   **[blazickjp/arxiv-mcp-server](https://github.com/blazickjp/arxiv-mcp-server)**: Searches research papers on ArXiv.
+-   **[mzxrai/mcp-webresearch](https://github.com/mzxrai/mcp-webresearch)**: Performs deep web research using Google search.
+-   **[andybrandt/mcp-simple-arxiv](https://github.com/andybrandt/mcp-simple-arxiv)**: Allows searching and reading papers from arXiv.
+-   **[andybrandt/mcp-simple-pubmed](https://github.com/andybrandt/mcp-simple-pubmed)**: Allows searching and reading papers from PubMed.
+
+### 🛠️ Utilities
+
+-   **[zcaceres/fetch-mcp](https://github.com/zcaceres/fetch-mcp)**: Fetches JSON, text, and HTML data flexibly from URLs.
+-   **[modelcontextprotocol/server-fetch](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch)**: Efficiently fetches and processes web content (part of the official servers collection).
+-   **[zcaceres/markdownify-mcp](https://github.com/zcaceres/markdownify-mcp)**: Converts various file types and web content to Markdown.
+-   **[@sammcj/mcp-package-version](https://github.com/sammcj/mcp-package-version)**: Helps LLMs suggest the latest stable package versions.
+-   **[@vivekvells/mcp-pandoc](https://github.com/vivekVells/mcp-pandoc)**: Converts document formats using Pandoc.
+-   **[@pskill9/website-downloader](https://github.com/pskill9/website-downloader)**: Downloads entire websites using wget, preserving structure.
+-   **[@lamemind/mcp-server-multiverse](https://github.com/lamemind/mcp-server-multiverse)**: Allows multiple isolated instances of MCP servers to coexist.
+-   **[@j4c0bs/mcp-server-sql-analyzer](https://github.com/j4c0bs/mcp-server-sql-analyzer)**: Provides SQL analysis, linting, and dialect conversion using SQLGlot.
+-   **[0xshellming/mcp-summarizer](https://github.com/0xshellming/mcp-summarizer)**: Provides AI summarization for multiple content types.
+-   **[SecretiveShell/MCP-timeserver](https://github.com/SecretiveShell/MCP-timeserver)**: Provides the current time in any timezone.
 
 comming soon.............


### PR DESCRIPTION
Hi Mobin,

This PR introduces several improvements to the Awesome MCP Servers list to enhance its readability, consistency, and accuracy. The goal is to make the list even more useful for the community.

Here's a summary of the changes:

Corrected Typos: Fixed minor typos in the introductory note (e.g., "continnuesly" -> "continuously") and removed the informal "comming soon" ending.

Standardized Naming: Updated the bolded names for entries to consistently use the user/repo or @org/repo format, making it easier to identify the source repository. Adjusted some descriptive names to match their repository paths (e.g., "Cloudflare MCP Server" -> cloudflare/mcp-server-cloudflare).

Consistent Descriptions: Refined descriptions to typically start with an action verb (e.g., "Integrates", "Provides", "Enables") for better flow and clarity.

Link Standardization: Adjusted some links pointing deep within repositories to link to the repository root where appropriate, providing broader context. Links to specific subdirectories were retained where necessary (e.g., for servers within monorepos like modelcontextprotocol/servers or quarkiverse/quarkus-mcp-servers). Added notes for clarity in these cases.

Removed Duplicates: Consolidated duplicate entries. Specifically, removed one of the Tavily integrations and removed the duplicate Tinybird entry from the CDP category (kept in Databases).

New "Utilities" Category: Created a new 🛠️ Utilities category and moved relevant general-purpose servers (like fetch, markdownify, pandoc conversion, time server, etc.) into it for better organization.

Minor Formatting: Made small adjustments for overall visual consistency.

These changes aim to improve the overall quality and usability of this valuable resource.

Thanks for maintaining this awesome list!